### PR TITLE
Fixed  warnings in 64bit mode by casting size_t to int

### DIFF
--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -47,8 +47,8 @@ namespace sqlpp
 			if (_handle->debug)
 				std::cerr << "Sqlite3 debug: binding boolean result " << *value << " at index: " << index << std::endl;
 
-			*value = sqlite3_column_int(_handle->sqlite_statement, index);
-			*is_null = sqlite3_column_type(_handle->sqlite_statement, index) == SQLITE_NULL;
+			*value = static_cast<signed char>(sqlite3_column_int(_handle->sqlite_statement, static_cast<int>(index)));
+			*is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
 		}
 
 		void bind_result_t::_bind_floating_point_result(size_t index, double* value, bool* is_null)
@@ -56,8 +56,8 @@ namespace sqlpp
 			if (_handle->debug)
 				std::cerr << "Sqlite3 debug: binding floating_point result " << *value << " at index: " << index << std::endl;
 
-			*value = sqlite3_column_double(_handle->sqlite_statement, index);
-			*is_null = sqlite3_column_type(_handle->sqlite_statement, index) == SQLITE_NULL;
+			*value = sqlite3_column_double(_handle->sqlite_statement, static_cast<int>(index));
+			*is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
 		}
 
 		void bind_result_t::_bind_integral_result(size_t index, int64_t* value, bool* is_null)
@@ -65,8 +65,8 @@ namespace sqlpp
 			if (_handle->debug)
 				std::cerr << "Sqlite3 debug: binding integral result " << *value << " at index: " << index << std::endl;
 
-			*value = sqlite3_column_int64(_handle->sqlite_statement, index);
-			*is_null = sqlite3_column_type(_handle->sqlite_statement, index) == SQLITE_NULL;
+			*value = sqlite3_column_int64(_handle->sqlite_statement, static_cast<int>(index));
+			*is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
 		}
 
 		void bind_result_t::_bind_text_result(size_t index, const char** value, size_t* len)
@@ -74,8 +74,8 @@ namespace sqlpp
 			if (_handle->debug)
 				std::cerr << "Sqlite3 debug: binding text result at index: " << index << std::endl;
 
-			*value = (reinterpret_cast<const char*>(sqlite3_column_text(_handle->sqlite_statement, index)));
-			*len = sqlite3_column_bytes(_handle->sqlite_statement, index);
+			*value = (reinterpret_cast<const char*>(sqlite3_column_text(_handle->sqlite_statement, static_cast<int>(index))));
+			*len = sqlite3_column_bytes(_handle->sqlite_statement, static_cast<int>(index));
 		}
 
 		bool bind_result_t::next_impl()

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -47,7 +47,7 @@ namespace sqlpp
 				auto rc = sqlite3_prepare_v2(
 						handle.sqlite,
 						statement.c_str(),
-						statement.size(),
+						static_cast<int>(statement.size()),
 						&result.sqlite_statement,
 						nullptr);
 

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -74,9 +74,9 @@ namespace sqlpp
 
 			int result;
 			if (not is_null)
-				result = sqlite3_bind_int(_handle->sqlite_statement, index + 1, *value);
+				result = sqlite3_bind_int(_handle->sqlite_statement, static_cast<int>(index + 1), *value);
 			else
-				result = sqlite3_bind_null(_handle->sqlite_statement, index + 1);
+				result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
 			check_bind_result(result, "boolean");
 		}
 
@@ -87,9 +87,9 @@ namespace sqlpp
 
 			int result;
 			if (not is_null)
-				result = sqlite3_bind_double(_handle->sqlite_statement, index + 1, *value);
+				result = sqlite3_bind_double(_handle->sqlite_statement, static_cast<int>(index + 1), *value);
 			else
-				result = sqlite3_bind_null(_handle->sqlite_statement, index + 1);
+				result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
 			check_bind_result(result, "floating_point");
 		}
 
@@ -100,9 +100,9 @@ namespace sqlpp
 
 			int result;
 			if (not is_null)
-				result = sqlite3_bind_int64(_handle->sqlite_statement, index + 1, *value);
+				result = sqlite3_bind_int64(_handle->sqlite_statement, static_cast<int>(index + 1), *value);
 			else
-				result = sqlite3_bind_null(_handle->sqlite_statement, index + 1);
+				result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
 			check_bind_result(result, "integral");
 		}
 
@@ -113,9 +113,9 @@ namespace sqlpp
 
 			int result;
 			if (not is_null)
-				result = sqlite3_bind_text(_handle->sqlite_statement, index + 1, value->data(), value->size(), SQLITE_STATIC);
+				result = sqlite3_bind_text(_handle->sqlite_statement, static_cast<int>(index + 1), value->data(), static_cast<int>(value->size()), SQLITE_STATIC);
 			else
-				result = sqlite3_bind_null(_handle->sqlite_statement, index + 1);
+				result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
 			check_bind_result(result, "text");
 		}
 	}


### PR DESCRIPTION
I got several warnings when compiling in 64bit mode, since size_t is assigned numerous times to int used by the sqlite api.
