### PR TITLE
Feature/native handle

### DIFF
--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -232,7 +232,7 @@ namespace sqlpp
 			}
 
 			//! execute arbitrary command (e.g. create a table)
-			void execute(const std::string& command);
+			size_t execute(const std::string& command);
 
 			//! escape given string (does not quote, though)
 			std::string escape(const std::string& s) const;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -125,10 +125,11 @@ namespace sqlpp
 			return sqlite3_last_insert_rowid(_handle->sqlite);
 		}
 
-		void connection::execute(const std::string& statement)
+		size_t connection::execute(const std::string& statement)
 		{
 			auto prepared = prepare_statement(*_handle, statement);
 			execute_statement(*_handle, prepared);
+			return sqlite3_changes(_handle->sqlite);
 		}
 
 		size_t connection::update_impl(const std::string& statement)


### PR DESCRIPTION
This change exposes the native `sqlite3*` handle. Additionally, I've exposed rows affected under the `connection::execute()` method.
