### PR TITLE
adding ctor`s for sqlite3 connection_config and some improvements for…

### DIFF
--- a/include/sqlpp11/sqlite3/connection_config.h
+++ b/include/sqlpp11/sqlite3/connection_config.h
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2013, Roland Bock
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above copyright notice, this
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,14 +37,21 @@ namespace sqlpp
 	{
 		struct connection_config
 		{
-			std::string path_to_database;
-			int flags = 0;
-			std::string vfs = "";
-			bool debug = false;
+			connection_config() = default;
+			connection_config(const connection_config &) = default;
+			connection_config(connection_config &&) = default;
+
+			connection_config(std::string path, int fl=0, std::string vf="", bool dbg=false)
+				:path_to_database(std::move(path))
+				,flags(fl)
+				,vfs(std::move(vf))
+				,debug(dbg)
+			{
+			}
 
 			bool operator==(const connection_config& other) const
 			{
-				return (other.path_to_database == path_to_database 
+				return (other.path_to_database == path_to_database
 						and other.flags == flags
 						and other.vfs == vfs
 						and other.debug == debug);
@@ -54,6 +61,11 @@ namespace sqlpp
 			{
 				return !operator==(other);
 			}
+
+			std::string path_to_database;
+			int flags;
+			std::string vfs;
+			bool debug;
 		};
 	}
 }

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2013, Roland Bock
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above copyright notice, this
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -76,7 +76,7 @@ namespace sqlpp
 		}
 
 		connection::connection(connection_config config):
-			_handle(new detail::connection_handle(config))
+			_handle(new detail::connection_handle(std::move(config)))
 		{
 		}
 
@@ -223,7 +223,7 @@ namespace sqlpp
 		{
 			std::cerr << "Sqlite3 message:" << message << std::endl;
 		}
-		
+
 		auto connection::attach(const connection_config& config, const std::string name)
 			-> schema_t
 		{

--- a/src/detail/connection_handle.cpp
+++ b/src/detail/connection_handle.cpp
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2013, Roland Bock
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above copyright notice, this
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -37,13 +37,13 @@ namespace sqlpp
 		namespace detail
 		{
 			connection_handle::connection_handle(connection_config conf):
-				config(conf),
+				config(std::move(conf)),
 				sqlite(nullptr)
 			{
 				auto rc = sqlite3_open_v2(
-						conf.path_to_database.c_str(), 
-						&sqlite, 
-						conf.flags, 
+						conf.path_to_database.c_str(),
+						&sqlite,
+						conf.flags,
 						conf.vfs.empty() ? nullptr : conf.vfs.c_str());
 				if (rc != SQLITE_OK)
 				{

--- a/tests/SelectTest.cpp
+++ b/tests/SelectTest.cpp
@@ -70,7 +70,7 @@ void testSelectAll(sql::connection& db, size_t expectedRowCount)
 
 int main()
 {
-	sql::connection db({":memory:", SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE, true});
+	sql::connection db({":memory:",SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE, "", true});
 	db.execute(R"(CREATE TABLE tab_sample (
 		alpha INTEGER PRIMARY KEY,
 			beta varchar(255) DEFAULT NULL,

--- a/tests/SelectTest.cpp
+++ b/tests/SelectTest.cpp
@@ -1,25 +1,25 @@
 /*
  * Copyright (c) 2013, Roland Bock
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without modification, 
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- *  * Redistributions of source code must retain the above copyright notice, 
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
  *    this list of conditions and the following disclaimer.
- *  * Redistributions in binary form must reproduce the above copyright notice, 
- *    this list of conditions and the following disclaimer in the documentation 
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
- * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
- * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF 
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE 
- * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED 
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -70,12 +70,7 @@ void testSelectAll(sql::connection& db, size_t expectedRowCount)
 
 int main()
 {
-	sql::connection_config config;
- 	config.path_to_database = ":memory:";
-	config.flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
-	config.debug = true;
-
-	sql::connection db(config);
+	sql::connection db({":memory:", SQLITE_OPEN_READWRITE|SQLITE_OPEN_CREATE, true});
 	db.execute(R"(CREATE TABLE tab_sample (
 		alpha INTEGER PRIMARY KEY,
 			beta varchar(255) DEFAULT NULL,


### PR DESCRIPTION
… connection/connection_handle


Hi,

This fixes make it possible initialize the 'sqlite3::connection' as a member of the class:
```cpp
struct db_controller {
   db_controller()
      db({"/home/nixman/dbtest/testdb.sqlite3", ...})
   {}
   sqlpp::sqlite3::connection db;
};
```
Until now this was impossible because 'connection_config' have default values for some members.