### PR TITLE
Removed redundant semicolon 

### DIFF
--- a/include/sqlpp11/sqlite3/bind_result.h
+++ b/include/sqlpp11/sqlite3/bind_result.h
@@ -1,17 +1,17 @@
 /*
  * Copyright (c) 2013, Roland Bock
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright notice, this
  *   list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above copyright notice, this
  *   list of conditions and the following disclaimer in the documentation and/or
  *   other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -79,7 +79,7 @@ namespace sqlpp
 					if (result_row)
 						result_row._invalidate();
 				}
-			};
+			}
 
 			void _bind_boolean_result(size_t index, signed char* value, bool* is_null);
 			void _bind_floating_point_result(size_t index, double* value, bool* is_null);


### PR DESCRIPTION
I just removed a redundant semicolon in bind_result.h
Nothing too complicated.

But as I always compile -pedantic -pedantic-errors, its quite a big deal for me.