### PR TITLE
missing bind for unsigned integral

### DIFF
--- a/include/sqlpp11/sqlite3/bind_result.h
+++ b/include/sqlpp11/sqlite3/bind_result.h
@@ -84,6 +84,7 @@ namespace sqlpp
       void _bind_boolean_result(size_t index, signed char* value, bool* is_null);
       void _bind_floating_point_result(size_t index, double* value, bool* is_null);
       void _bind_integral_result(size_t index, int64_t* value, bool* is_null);
+      void _bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null);
       void _bind_text_result(size_t index, const char** text, size_t* len);
       void _bind_date_result(size_t index, ::sqlpp::chrono::day_point* value, bool* is_null);
       void _bind_date_time_result(size_t index, ::sqlpp::chrono::microsecond_point* value, bool* is_null);

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -70,6 +70,15 @@ namespace sqlpp
       *is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
     }
 
+    void bind_result_t::_bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null)
+    {
+      if (_handle->debug)
+        std::cerr << "Sqlite3 debug: binding unsigned integral result " << *value << " at index: " << index << std::endl;
+
+      *value = sqlite3_column_int64(_handle->sqlite_statement, static_cast<int>(index));
+      *is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
+    }
+
     void bind_result_t::_bind_text_result(size_t index, const char** value, size_t* len)
     {
       if (_handle->debug)


### PR DESCRIPTION
Hello,
I wish to use unsigned integral type in field but bind_result_t::_bind_unsigned_integral_result is missing.
Best regards.
Matthieu