### PR TITLE
Fix sqlite3_key call

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,24 @@ __Libraries:__
   * sqlpp11-connector-sqlite3 is meant to be used with sqlpp11 (https://github.com/rbock/sqlpp11).
   * sqlpp11 requires date.h (https://github.com/HowardHinnant/date).
   * libsqlite3, version 3.7.11 or later is required to use multi-row insert. Older versions (e.g. 3.7.9) work fine otherwise.
+
+Breaking Changes:
+-----------------
+__Version 0.24, handling of password for encrypted databases:__
+
+The call to sqlite3_key used to include a null character at the end of the
+password provided in the connection_config. This prevented users from using the
+"x'HEXHEXHEX'" syntax that skips the key derivation and made interoperability
+with other tools more complex.
+
+The call has been fixed, which implies that databases created with sqlpp11 won't
+open anymore without changing user code. To adapt to this change, you must
+explicitely append a null character to the database password:
+
+```C++
+config.password.push_back('\0');
+```
+
+You can also update your database to migrate them to a password without the
+extra null character with
+[sqlite3_rekey](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlite3_rekey).

--- a/src/detail/connection_handle.cpp
+++ b/src/detail/connection_handle.cpp
@@ -48,7 +48,7 @@ namespace sqlpp
 #ifdef SQLITE_HAS_CODEC
         if (conf.password.size()>0)
         {
-          int ret = sqlite3_key(sqlite, conf.password.data(),conf.password.size()+1);
+          int ret = sqlite3_key(sqlite, conf.password.data(),conf.password.size());
           if (ret!=SQLITE_OK)
           {
             const std::string msg = sqlite3_errmsg(sqlite);


### PR DESCRIPTION
The call to sqlite3_key included a null char with the key which makes it impossible to make use of existing databases.

Unfortunately, this fix will probably break existing code from users who created their database with the previous version, they will need to add a null char to their key.