### PR TITLE
Dynamic Loading for SQLite connector

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,6 +21,8 @@ build_script:
   - cl /c /EHsc sqlite3.c
   - lib sqlite3.obj
   - cd ..
+  - wget https://sqlite.org/2017/sqlite-dll-win64-x64-3190200.zip
+  - unzip sqlite-dll-win64-x64-3190200.zip
   - cd ..
   - CD
   - git clone https://github.com/HowardHinnant/date
@@ -36,5 +38,6 @@ build_script:
   - cmake --version
   - cmake .. -DCMAKE_PREFIX_PATH="C:/projects/sqlpp11-connector-sqlite3/sqlite-amalgamation-3120200" -DCMAKE_CXX_FLAGS="/EHsc /wd4503" -DCMAKE_GENERATOR_PLATFORM=x64
   - cmake --build . --config %configuration%
+  - copy ..\sqlite3.dll tests\
   - ctest . --output-on-failure --build-config %configuration%
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,6 +24,9 @@ build_script:
   - cd ..
   - CD
   - git clone https://github.com/HowardHinnant/date
+  - cd date
+  - git checkout tags/v2.0.0
+  - cd ..
   - git clone https://github.com/rbock/sqlpp11
   - cd sqlpp11-connector-sqlite3
   - CD

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,13 @@ addons:
     - sqlite3
     - libboost-dev
 
-osx_image: xcode7
-
 compiler:
   - clang
   - gcc
 
 env:
   - CONFIG=Release
-  - CONFIG=Debug
+  #- CONFIG=Debug
 
 notifications:
  email:
@@ -28,13 +26,13 @@ notifications:
    on_failure: always
 
 install:
+  - g++ --version
+  - cmake --version
   - pwd
   - PROJECT_DIR="$PWD"
   - BRANCH=`git rev-parse --abbrev-ref HEAD`
   - cd ..
   - pwd
-  - CMAKE_VERSION_MM=3.2
-  - CMAKE_VERSION_FULL=$CMAKE_VERSION_MM.2
   - git clone https://github.com/HowardHinnant/date
   - cd date
   - git checkout tags/v1.0.0
@@ -44,18 +42,6 @@ install:
       cd sqlpp11
       && git checkout develop
       && cd ..
-      ;
-    fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-      wget --no-check-certificate http://www.cmake.org/files/v${CMAKE_VERSION_MM}/cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.sh
-      && sudo sh cmake-${CMAKE_VERSION_FULL}-Linux-x86_64.sh --prefix=/usr/local --exclude-subdir;
-    fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      brew update
-      && ((brew list -1 | grep -q "^$cmake\$") || brew install cmake)
-      && (brew outdated cmake || brew upgrade cmake)
-      && cmake --version
-      && brew install sqlite3
       ;
     fi
   - cd "$PROJECT_DIR"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - pwd
   - git clone https://github.com/HowardHinnant/date
   - cd date
-  - git checkout tags/v1.0.0
+  - git checkout tags/v2.0.0
   - cd ..
   - git clone https://github.com/rbock/sqlpp11
   - if [ "$BRANCH" != "master" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,10 @@ project (sqlpp11-connector-sqlite3)
 enable_testing()
 set(CMAKE_CXX_STANDARD 11)
 
+## Setup custom location for SQlite build if needed
+# set(SQLITE3_LIBRARY "../../sqlite-amalgamation-3120200/sqlite3")
+# set(SQLITE3_INCLUDE_DIR "sqlite-amalgamation-3120200")
+
 option(SQLCIPHER "Build with sqlcipher" Off)
 option(ENABLE_TESTS "Build unit tests" On)
 
@@ -39,8 +43,6 @@ if(SQLCIPHER )
 else()
 	find_package(Sqlite3 REQUIRED)
 endif()
-
-
 
 message(STATUS "Using ${CMAKE_CXX_COMPILER} (compiler id: ${CMAKE_CXX_COMPILER_ID})")
 

--- a/README.md
+++ b/README.md
@@ -51,3 +51,24 @@ __Libraries:__
   * sqlpp11-connector-sqlite3 is meant to be used with sqlpp11 (https://github.com/rbock/sqlpp11).
   * sqlpp11 requires date.h (https://github.com/HowardHinnant/date).
   * libsqlite3, version 3.7.11 or later is required to use multi-row insert. Older versions (e.g. 3.7.9) work fine otherwise.
+
+Breaking Changes:
+-----------------
+__Version 0.24, handling of password for encrypted databases:__
+
+The call to sqlite3_key used to include a null character at the end of the
+password provided in the connection_config. This prevented users from using the
+"x'HEXHEXHEX'" syntax that skips the key derivation and made interoperability
+with other tools more complex.
+
+The call has been fixed, which implies that databases created with sqlpp11 won't
+open anymore without changing user code. To adapt to this change, you must
+explicitely append a null character to the database password:
+
+```C++
+config.password.push_back('\0');
+```
+
+You can also update your database to migrate them to a password without the
+extra null character with
+[sqlite3_rekey](https://www.zetetic.net/sqlcipher/sqlcipher-api/#sqlite3_rekey).

--- a/include/sqlpp11/sqlite3/dynamic_libsqlite3.h
+++ b/include/sqlpp11/sqlite3/dynamic_libsqlite3.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2015, Volker Aßmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef DYNAMIC_LIBSQLITE3_H
+#define DYNAMIC_LIBSQLITE3_H
+
+#include <sqlite3.h>
+#include <stdexcept>
+
+// namespace for internal sqlite function wrappers - when using this instead of sqlite3 direct linking
+// do this:
+//    using namespace sqlpp::sqlite3::dyn;
+// to override the libsqlite3 functions with these function pointers
+
+#ifdef SQLPP_DYNAMIC_LOADING
+
+namespace sqlpp
+{
+  namespace sqlite3
+  {
+    namespace dynamic
+    {
+      /// load the SQLite libraries, optionally providing the filename (leave empty for default)
+      void init_sqlite(std::string libname);
+
+#define DYNDEFINE(NAME) extern decltype(::NAME)* NAME
+
+      DYNDEFINE(sqlite3_open_v2);
+      DYNDEFINE(sqlite3_open);
+      DYNDEFINE(sqlite3_prepare_v2);
+      DYNDEFINE(sqlite3_exec);
+      DYNDEFINE(sqlite3_step);
+      DYNDEFINE(sqlite3_bind_int);
+      DYNDEFINE(sqlite3_close);
+      DYNDEFINE(sqlite3_initialize);
+      DYNDEFINE(sqlite3_os_init);
+      DYNDEFINE(sqlite3_os_end);
+      DYNDEFINE(sqlite3_bind_blob);
+      DYNDEFINE(sqlite3_bind_double);
+      DYNDEFINE(sqlite3_bind_int64);
+      DYNDEFINE(sqlite3_bind_null);
+      DYNDEFINE(sqlite3_bind_text);
+      DYNDEFINE(sqlite3_bind_value);
+      DYNDEFINE(sqlite3_libversion_number);
+      //    DYNDEFINE(sqlite3_compileoption_used);
+      DYNDEFINE(sqlite3_threadsafe);
+      //    DYNDEFINE(sqlite3_close_v2);
+      DYNDEFINE(sqlite3_shutdown);
+      DYNDEFINE(sqlite3_config);
+      DYNDEFINE(sqlite3_db_config);
+      DYNDEFINE(sqlite3_extended_result_codes);
+      DYNDEFINE(sqlite3_last_insert_rowid);
+      DYNDEFINE(sqlite3_changes);
+      DYNDEFINE(sqlite3_total_changes);
+      DYNDEFINE(sqlite3_interrupt);
+      DYNDEFINE(sqlite3_complete);
+      DYNDEFINE(sqlite3_complete16);
+      DYNDEFINE(sqlite3_busy_handler);
+      DYNDEFINE(sqlite3_busy_timeout);
+      DYNDEFINE(sqlite3_get_table);
+      DYNDEFINE(sqlite3_free_table);
+      //    DYNDEFINE(sqlite3_realloc64);
+      DYNDEFINE(sqlite3_free);
+      //    DYNDEFINE(sqlite3_msize);
+      DYNDEFINE(sqlite3_memory_used);
+      DYNDEFINE(sqlite3_memory_highwater);
+      DYNDEFINE(sqlite3_randomness);
+      DYNDEFINE(sqlite3_set_authorizer);
+      DYNDEFINE(sqlite3_progress_handler);
+      DYNDEFINE(sqlite3_open16);
+      //    DYNDEFINE(sqlite3_uri_boolean);
+      //    DYNDEFINE(sqlite3_uri_int64);
+      DYNDEFINE(sqlite3_errcode);
+      DYNDEFINE(sqlite3_errmsg);
+      DYNDEFINE(sqlite3_extended_errcode);
+      DYNDEFINE(sqlite3_limit);
+      DYNDEFINE(sqlite3_prepare);
+      DYNDEFINE(sqlite3_prepare16);
+      DYNDEFINE(sqlite3_prepare16_v2);
+      //    DYNDEFINE(sqlite3_stmt_readonly);
+      //    DYNDEFINE(sqlite3_stmt_busy);
+      //    DYNDEFINE(sqlite3_bind_blob64);
+      DYNDEFINE(sqlite3_bind_text16);
+      //    DYNDEFINE(sqlite3_bind_text64);
+      DYNDEFINE(sqlite3_bind_zeroblob);
+      DYNDEFINE(sqlite3_bind_parameter_count);
+      DYNDEFINE(sqlite3_bind_parameter_index);
+      DYNDEFINE(sqlite3_clear_bindings);
+      DYNDEFINE(sqlite3_column_count);
+      DYNDEFINE(sqlite3_data_count);
+      DYNDEFINE(sqlite3_column_bytes);
+      DYNDEFINE(sqlite3_column_bytes16);
+      DYNDEFINE(sqlite3_column_double);
+      DYNDEFINE(sqlite3_column_int);
+      DYNDEFINE(sqlite3_column_int64);
+      DYNDEFINE(sqlite3_column_text);
+      DYNDEFINE(sqlite3_column_type);
+      DYNDEFINE(sqlite3_column_value);
+      DYNDEFINE(sqlite3_finalize);
+      DYNDEFINE(sqlite3_reset);
+      DYNDEFINE(sqlite3_create_function);
+      DYNDEFINE(sqlite3_create_function16);
+      //    DYNDEFINE(sqlite3_create_function_v2);
+      DYNDEFINE(sqlite3_value_bytes);
+      DYNDEFINE(sqlite3_value_bytes16);
+      DYNDEFINE(sqlite3_value_double);
+      DYNDEFINE(sqlite3_value_int);
+      DYNDEFINE(sqlite3_value_int64);
+      DYNDEFINE(sqlite3_value_type);
+      DYNDEFINE(sqlite3_value_numeric_type);
+      DYNDEFINE(sqlite3_set_auxdata);
+      DYNDEFINE(sqlite3_result_blob);
+      //    DYNDEFINE(sqlite3_result_blob64);
+      DYNDEFINE(sqlite3_result_double);
+      DYNDEFINE(sqlite3_result_error);
+      DYNDEFINE(sqlite3_result_error16);
+      DYNDEFINE(sqlite3_result_error_toobig);
+      DYNDEFINE(sqlite3_result_error_nomem);
+      DYNDEFINE(sqlite3_result_error_code);
+      DYNDEFINE(sqlite3_result_int);
+      DYNDEFINE(sqlite3_result_int64);
+      DYNDEFINE(sqlite3_result_null);
+      DYNDEFINE(sqlite3_result_text);
+      //    DYNDEFINE(sqlite3_result_text64);
+      DYNDEFINE(sqlite3_result_text16);
+      DYNDEFINE(sqlite3_result_text16le);
+      DYNDEFINE(sqlite3_result_text16be);
+      DYNDEFINE(sqlite3_result_value);
+      DYNDEFINE(sqlite3_result_zeroblob);
+      DYNDEFINE(sqlite3_create_collation);
+      DYNDEFINE(sqlite3_create_collation_v2);
+      DYNDEFINE(sqlite3_create_collation16);
+      DYNDEFINE(sqlite3_collation_needed);
+      DYNDEFINE(sqlite3_collation_needed16);
+
+#ifdef SQLITE_HAS_CODEC
+
+      DYNDEFINE(sqlite3_key);
+      DYNDEFINE(sqlite3_key_v2);
+      DYNDEFINE(sqlite3_rekey);
+      DYNDEFINE(sqlite3_rekey_v2);
+      DYNDEFINE(sqlite3_activate_see);
+#endif
+#ifdef SQLITE_ENABLE_CEROD
+      DYNDEFINE(sqlite3_activate_cerod);
+#endif
+      DYNDEFINE(sqlite3_sleep);
+      DYNDEFINE(sqlite3_get_autocommit);
+      //    DYNDEFINE(sqlite3_db_readonly);
+      DYNDEFINE(sqlite3_next_stmt);
+      DYNDEFINE(sqlite3_enable_shared_cache);
+      DYNDEFINE(sqlite3_release_memory);
+      //    DYNDEFINE(sqlite3_db_release_memory);
+      //    DYNDEFINE(sqlite3_soft_heap_limit64);
+      DYNDEFINE(sqlite3_table_column_metadata);
+      DYNDEFINE(sqlite3_load_extension);
+      DYNDEFINE(sqlite3_enable_load_extension);
+      DYNDEFINE(sqlite3_auto_extension);
+      //    DYNDEFINE(sqlite3_cancel_auto_extension);
+      DYNDEFINE(sqlite3_reset_auto_extension);
+      DYNDEFINE(sqlite3_create_module);
+      DYNDEFINE(sqlite3_create_module_v2);
+      DYNDEFINE(sqlite3_declare_vtab);
+      DYNDEFINE(sqlite3_overload_function);
+      DYNDEFINE(sqlite3_blob_open);
+      DYNDEFINE(sqlite3_blob_close);
+      DYNDEFINE(sqlite3_blob_bytes);
+      DYNDEFINE(sqlite3_blob_read);
+      DYNDEFINE(sqlite3_blob_write);
+      DYNDEFINE(sqlite3_vfs_find);
+      DYNDEFINE(sqlite3_vfs_register);
+      DYNDEFINE(sqlite3_vfs_unregister);
+      DYNDEFINE(sqlite3_mutex_alloc);
+      DYNDEFINE(sqlite3_mutex_free);
+      DYNDEFINE(sqlite3_mutex_enter);
+      DYNDEFINE(sqlite3_mutex_try);
+      DYNDEFINE(sqlite3_mutex_leave);
+      //    DYNDEFINE(sqlite3_mutex_held);
+      //    DYNDEFINE(sqlite3_mutex_notheld);
+      DYNDEFINE(sqlite3_db_mutex);
+      DYNDEFINE(sqlite3_file_control);
+      DYNDEFINE(sqlite3_test_control);
+      DYNDEFINE(sqlite3_status);
+      DYNDEFINE(sqlite3_db_status);
+      DYNDEFINE(sqlite3_stmt_status);
+      DYNDEFINE(sqlite3_backup_init);
+      DYNDEFINE(sqlite3_backup_step);
+      DYNDEFINE(sqlite3_backup_finish);
+      DYNDEFINE(sqlite3_backup_remaining);
+      DYNDEFINE(sqlite3_backup_pagecount);
+      DYNDEFINE(sqlite3_unlock_notify);
+      //    DYNDEFINE(sqlite3_stricmp);
+      //    DYNDEFINE(sqlite3_strnicmp);
+      //    DYNDEFINE(sqlite3_strglob);
+      //    DYNDEFINE(sqlite3_log);
+      //    DYNDEFINE(sqlite3_wal_autocheckpoint);
+      //    DYNDEFINE(sqlite3_wal_checkpoint);
+      //    DYNDEFINE(sqlite3_wal_checkpoint_v2);
+      //    DYNDEFINE(sqlite3_vtab_config);
+      //    DYNDEFINE(sqlite3_vtab_on_conflict);
+      //    DYNDEFINE(sqlite3_rtree_geometry_callback);
+      //    DYNDEFINE(sqlite3_rtree_query_callback);
+    }
+  }
+}
+
+#undef DYNDEFINE
+
+#endif
+#endif  // DYNAMIC_LIBSQLITE3_H

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,20 @@ add_library(sqlpp11-connector-sqlite3
 		connection.cpp
 		bind_result.cpp
 		prepared_statement.cpp
-		detail/connection_handle.cpp)
+		detail/connection_handle.cpp
+      )
+
+add_library(sqlpp11-connector-sqlite3-dynamic
+                connection.cpp
+                bind_result.cpp
+                prepared_statement.cpp
+                detail/connection_handle.cpp
+                detail/dynamic_libsqlite3.cpp
+    )
+
+get_filename_component(SQLITE3_LIB_FILE ${SQLITE3_LIBRARIES} NAME)
+target_compile_options(sqlpp11-connector-sqlite3-dynamic INTERFACE -DSQLPP_DYNAMIC_LOADING)
+target_compile_options(sqlpp11-connector-sqlite3-dynamic PRIVATE -DSQLPP_DYNAMIC_LOADING -DSQLPP_DYNAMIC_LOADING_FILENAME=${SQLITE3_LIB_FILE})
 
 install(TARGETS sqlpp11-connector-sqlite3 DESTINATION lib)
+install(TARGETS sqlpp11-connector-sqlite3-dynamic DESTINATION lib)

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -33,10 +33,19 @@
 #include <sqlpp11/sqlite3/bind_result.h>
 #include "detail/prepared_statement_handle.h"
 
+#ifdef SQLPP_DYNAMIC_LOADING
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
+#endif
+
 namespace sqlpp
 {
   namespace sqlite3
   {
+
+#ifdef SQLPP_DYNAMIC_LOADING
+   using namespace dynamic;
+#endif
+
     bind_result_t::bind_result_t(const std::shared_ptr<detail::prepared_statement_handle_t>& handle) : _handle(handle)
     {
       if (_handle and _handle->debug)

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -30,10 +30,19 @@
 #include <sqlpp11/exception.h>
 #include <sqlpp11/sqlite3/connection.h>
 
+#ifdef SQLPP_DYNAMIC_LOADING
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
+#endif
+
 namespace sqlpp
 {
   namespace sqlite3
   {
+
+#ifdef SQLPP_DYNAMIC_LOADING
+  using namespace dynamic;
+#endif
+
     namespace
     {
       detail::prepared_statement_handle_t prepare_statement(detail::connection_handle& handle,

--- a/src/detail/connection_handle.cpp
+++ b/src/detail/connection_handle.cpp
@@ -48,7 +48,7 @@ namespace sqlpp
 #ifdef SQLITE_HAS_CODEC
         if (conf.password.size()>0)
         {
-          int ret = sqlite3_key(sqlite, conf.password.data(),conf.password.size()+1);
+          int ret = sqlite3_key(sqlite, conf.password.data(),conf.password.size());
           if (ret!=SQLITE_OK)
           {
             const std::string msg = sqlite3_errmsg(sqlite);

--- a/src/detail/connection_handle.cpp
+++ b/src/detail/connection_handle.cpp
@@ -29,14 +29,27 @@
 #include <sqlpp11/sqlite3/connection_config.h>
 #include "connection_handle.h"
 
+#ifdef SQLPP_DYNAMIC_LOADING
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
+#endif
+
 namespace sqlpp
 {
   namespace sqlite3
   {
+
+#ifdef SQLPP_DYNAMIC_LOADING
+  using namespace dynamic;
+#endif
+
     namespace detail
     {
       connection_handle::connection_handle(connection_config conf) : config(conf), sqlite(nullptr)
       {
+#ifdef SQLPP_DYNAMIC_LOADING
+        init_sqlite("");
+#endif
+        
         auto rc = sqlite3_open_v2(conf.path_to_database.c_str(), &sqlite, conf.flags,
                                   conf.vfs.empty() ? nullptr : conf.vfs.c_str());
         if (rc != SQLITE_OK)

--- a/src/detail/dynamic_libsqlite3.cpp
+++ b/src/detail/dynamic_libsqlite3.cpp
@@ -1,0 +1,470 @@
+/*
+ * Copyright (c) 2015, Volker Assmann
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "sqlpp11/sqlite3/dynamic_libsqlite3.h"
+#include "sqlpp11/exception.h"
+
+#include <cassert>
+#include <string>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <dlfcn.h>
+#else
+#include <Windows.h>
+#endif
+
+#ifdef SQLPP_DYNAMIC_LOADING
+
+namespace sqlpp
+{
+  namespace sqlite3
+  {
+    namespace dynamic
+    {
+#define DYNDEFINE(NAME) decltype(::NAME)* NAME
+
+#if defined(__linux__) || defined(__APPLE__)
+#define DYNLOAD(HNDL, NAME) NAME = reinterpret_cast<decltype(NAME)>(dlsym(HNDL, #NAME))
+#else
+#define DYNLOAD(HNDL, NAME) NAME = reinterpret_cast<decltype(NAME)>(GetProcAddress(HNDL, #NAME))
+#endif
+
+      DYNDEFINE(sqlite3_open_v2);
+      DYNDEFINE(sqlite3_open);
+      DYNDEFINE(sqlite3_prepare_v2);
+      DYNDEFINE(sqlite3_exec);
+      DYNDEFINE(sqlite3_step);
+      DYNDEFINE(sqlite3_bind_int);
+      DYNDEFINE(sqlite3_close);
+      DYNDEFINE(sqlite3_initialize);
+      DYNDEFINE(sqlite3_os_init);
+      DYNDEFINE(sqlite3_os_end);
+      DYNDEFINE(sqlite3_bind_blob);
+      DYNDEFINE(sqlite3_bind_double);
+      DYNDEFINE(sqlite3_bind_int64);
+      DYNDEFINE(sqlite3_bind_null);
+      DYNDEFINE(sqlite3_bind_text);
+      DYNDEFINE(sqlite3_bind_value);
+      DYNDEFINE(sqlite3_libversion_number);
+      // DYNDEFINE(sqlite3_compileoption_used);
+      DYNDEFINE(sqlite3_threadsafe);
+      // DYNDEFINE(sqlite3_close_v2);
+      DYNDEFINE(sqlite3_shutdown);
+      DYNDEFINE(sqlite3_config);
+      DYNDEFINE(sqlite3_db_config);
+      DYNDEFINE(sqlite3_extended_result_codes);
+      DYNDEFINE(sqlite3_last_insert_rowid);
+      DYNDEFINE(sqlite3_changes);
+      DYNDEFINE(sqlite3_total_changes);
+      DYNDEFINE(sqlite3_interrupt);
+      DYNDEFINE(sqlite3_complete);
+      DYNDEFINE(sqlite3_complete16);
+      DYNDEFINE(sqlite3_busy_handler);
+      DYNDEFINE(sqlite3_busy_timeout);
+      DYNDEFINE(sqlite3_get_table);
+      DYNDEFINE(sqlite3_free_table);
+      // DYNDEFINE(sqlite3_realloc64);
+      DYNDEFINE(sqlite3_free);
+      // DYNDEFINE(sqlite3_msize);
+      DYNDEFINE(sqlite3_memory_used);
+      DYNDEFINE(sqlite3_memory_highwater);
+      DYNDEFINE(sqlite3_randomness);
+      DYNDEFINE(sqlite3_set_authorizer);
+      DYNDEFINE(sqlite3_progress_handler);
+      DYNDEFINE(sqlite3_open16);
+      // DYNDEFINE(sqlite3_uri_boolean);
+      // DYNDEFINE(sqlite3_uri_int64);
+      DYNDEFINE(sqlite3_errcode);
+      DYNDEFINE(sqlite3_errmsg);
+      DYNDEFINE(sqlite3_extended_errcode);
+      DYNDEFINE(sqlite3_limit);
+      DYNDEFINE(sqlite3_prepare);
+      DYNDEFINE(sqlite3_prepare16);
+      DYNDEFINE(sqlite3_prepare16_v2);
+      // DYNDEFINE(sqlite3_stmt_readonly);
+      // DYNDEFINE(sqlite3_stmt_busy);
+      // DYNDEFINE(sqlite3_bind_blob64);
+      DYNDEFINE(sqlite3_bind_text16);
+      // DYNDEFINE(sqlite3_bind_text64);
+      DYNDEFINE(sqlite3_bind_zeroblob);
+      DYNDEFINE(sqlite3_bind_parameter_count);
+      DYNDEFINE(sqlite3_bind_parameter_index);
+      DYNDEFINE(sqlite3_clear_bindings);
+      DYNDEFINE(sqlite3_column_count);
+      DYNDEFINE(sqlite3_data_count);
+      DYNDEFINE(sqlite3_column_bytes);
+      DYNDEFINE(sqlite3_column_bytes16);
+      DYNDEFINE(sqlite3_column_double);
+      DYNDEFINE(sqlite3_column_int);
+      DYNDEFINE(sqlite3_column_int64);
+      DYNDEFINE(sqlite3_column_text);
+      DYNDEFINE(sqlite3_column_type);
+      DYNDEFINE(sqlite3_column_value);
+      DYNDEFINE(sqlite3_finalize);
+      DYNDEFINE(sqlite3_reset);
+      DYNDEFINE(sqlite3_create_function);
+      DYNDEFINE(sqlite3_create_function16);
+      // DYNDEFINE(sqlite3_create_function_v2);
+      DYNDEFINE(sqlite3_value_bytes);
+      DYNDEFINE(sqlite3_value_bytes16);
+      DYNDEFINE(sqlite3_value_double);
+      DYNDEFINE(sqlite3_value_int);
+      DYNDEFINE(sqlite3_value_int64);
+      DYNDEFINE(sqlite3_value_type);
+      DYNDEFINE(sqlite3_value_numeric_type);
+      DYNDEFINE(sqlite3_set_auxdata);
+      DYNDEFINE(sqlite3_result_blob);
+      // DYNDEFINE(sqlite3_result_blob64);
+      DYNDEFINE(sqlite3_result_double);
+      DYNDEFINE(sqlite3_result_error);
+      DYNDEFINE(sqlite3_result_error16);
+      DYNDEFINE(sqlite3_result_error_toobig);
+      DYNDEFINE(sqlite3_result_error_nomem);
+      DYNDEFINE(sqlite3_result_error_code);
+      DYNDEFINE(sqlite3_result_int);
+      DYNDEFINE(sqlite3_result_int64);
+      DYNDEFINE(sqlite3_result_null);
+      DYNDEFINE(sqlite3_result_text);
+      // DYNDEFINE(sqlite3_result_text64);
+      DYNDEFINE(sqlite3_result_text16);
+      DYNDEFINE(sqlite3_result_text16le);
+      DYNDEFINE(sqlite3_result_text16be);
+      DYNDEFINE(sqlite3_result_value);
+      DYNDEFINE(sqlite3_result_zeroblob);
+      DYNDEFINE(sqlite3_create_collation);
+      DYNDEFINE(sqlite3_create_collation_v2);
+      DYNDEFINE(sqlite3_create_collation16);
+      DYNDEFINE(sqlite3_collation_needed);
+      DYNDEFINE(sqlite3_collation_needed16);
+
+#ifdef SQLITE_HAS_CODEC
+
+      DYNDEFINE(sqlite3_key);
+      DYNDEFINE(sqlite3_key_v2);
+      DYNDEFINE(sqlite3_rekey);
+      DYNDEFINE(sqlite3_rekey_v2);
+      DYNDEFINE(sqlite3_activate_see);
+#endif
+#ifdef SQLITE_ENABLE_CEROD
+      DYNDEFINE(sqlite3_activate_cerod);
+#endif
+      DYNDEFINE(sqlite3_sleep);
+      DYNDEFINE(sqlite3_get_autocommit);
+      // DYNDEFINE(sqlite3_db_readonly);
+      DYNDEFINE(sqlite3_next_stmt);
+      DYNDEFINE(sqlite3_enable_shared_cache);
+      DYNDEFINE(sqlite3_release_memory);
+      // DYNDEFINE(sqlite3_db_release_memory);
+      // DYNDEFINE(sqlite3_soft_heap_limit64);
+      DYNDEFINE(sqlite3_table_column_metadata);
+      DYNDEFINE(sqlite3_load_extension);
+      DYNDEFINE(sqlite3_enable_load_extension);
+      DYNDEFINE(sqlite3_auto_extension);
+      // DYNDEFINE(sqlite3_cancel_auto_extension);
+      DYNDEFINE(sqlite3_reset_auto_extension);
+      DYNDEFINE(sqlite3_create_module);
+      DYNDEFINE(sqlite3_create_module_v2);
+      DYNDEFINE(sqlite3_declare_vtab);
+      DYNDEFINE(sqlite3_overload_function);
+      DYNDEFINE(sqlite3_blob_open);
+      DYNDEFINE(sqlite3_blob_close);
+      DYNDEFINE(sqlite3_blob_bytes);
+      DYNDEFINE(sqlite3_blob_read);
+      DYNDEFINE(sqlite3_blob_write);
+      DYNDEFINE(sqlite3_vfs_find);
+      DYNDEFINE(sqlite3_vfs_register);
+      DYNDEFINE(sqlite3_vfs_unregister);
+      DYNDEFINE(sqlite3_mutex_alloc);
+      DYNDEFINE(sqlite3_mutex_free);
+      DYNDEFINE(sqlite3_mutex_enter);
+      DYNDEFINE(sqlite3_mutex_try);
+      DYNDEFINE(sqlite3_mutex_leave);
+      // DYNDEFINE(sqlite3_mutex_held);
+      // DYNDEFINE(sqlite3_mutex_notheld);
+      DYNDEFINE(sqlite3_db_mutex);
+      DYNDEFINE(sqlite3_file_control);
+      DYNDEFINE(sqlite3_test_control);
+      DYNDEFINE(sqlite3_status);
+      DYNDEFINE(sqlite3_db_status);
+      DYNDEFINE(sqlite3_stmt_status);
+      DYNDEFINE(sqlite3_backup_init);
+      DYNDEFINE(sqlite3_backup_step);
+      DYNDEFINE(sqlite3_backup_finish);
+      DYNDEFINE(sqlite3_backup_remaining);
+      DYNDEFINE(sqlite3_backup_pagecount);
+      DYNDEFINE(sqlite3_unlock_notify);
+// DYNDEFINE(sqlite3_stricmp);
+// DYNDEFINE(sqlite3_strnicmp);
+// DYNDEFINE(sqlite3_strglob);
+// DYNDEFINE(sqlite3_log);
+// DYNDEFINE(sqlite3_wal_autocheckpoint);
+// DYNDEFINE(sqlite3_wal_checkpoint);
+// DYNDEFINE(sqlite3_wal_checkpoint_v2);
+// DYNDEFINE(sqlite3_vtab_config);
+// DYNDEFINE(sqlite3_vtab_on_conflict);
+// DYNDEFINE(sqlite3_rtree_geometry_callback);
+// DYNDEFINE(sqlite3_rtree_query_callback);
+
+#define STR(x) #x
+#define GET_STR(x) STR(x)
+
+#ifndef SQLPP_DYNAMIC_LOADING_FILENAME
+#ifdef __linux__
+#define SQLPP_DYNAMIC_LOADING_FILENAME libsqlite3.so
+#elif __APPLE__
+#define SQLPP_DYNAMIC_LOADING_FILENAME libsqlite3.dylib
+#endif
+#endif
+
+// for windows, don't use the CMake provided SQLPP_DYNAMIC_LOADING_FILENAME as it will be the
+// static libs name
+#ifdef _WIN32
+#define SQLPP_DYNAMIC_LOADING_FILENAME sqlite3.dll
+#endif
+
+      void init_sqlite(std::string libname)
+      {
+        if (libname.empty())
+        {
+          libname = GET_STR(SQLPP_DYNAMIC_LOADING_FILENAME);
+        }
+#if defined(__linux__) || defined(__APPLE__)
+        void* handle = nullptr;
+        handle = dlopen(libname.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+#else
+        HINSTANCE handle = nullptr;
+        handle = LoadLibrary(libname.c_str());
+#endif
+
+#undef STR
+#undef GET_STR
+
+        if (!handle)
+        {
+#if defined(__linux__) || defined(__APPLE__)
+          throw sqlpp::exception(std::string("Could not load library " + libname + ": ").append(dlerror()));
+#elif defined(_WIN32)
+          if (GetLastError() == 193)
+          {
+            throw sqlpp::exception(
+                "Could not load SQLite library - error code indicates you are mixing 32/64 bit DLLs (lib: " + libname +
+                ")");
+          }
+          else
+          {
+            throw sqlpp::exception("Could not load lib using LoadLibrary (" + libname + ")");
+          }
+#endif
+        }
+
+        DYNLOAD(handle, sqlite3_libversion_number);
+        //   DYNLOAD(handle, sqlite3_compileoption_used);
+        DYNLOAD(handle, sqlite3_threadsafe);
+        DYNLOAD(handle, sqlite3_close);
+        //   DYNLOAD(handle, sqlite3_close_v2);
+        DYNLOAD(handle, sqlite3_exec);
+        DYNLOAD(handle, sqlite3_initialize);
+        DYNLOAD(handle, sqlite3_shutdown);
+        DYNLOAD(handle, sqlite3_os_init);
+        DYNLOAD(handle, sqlite3_os_end);
+        DYNLOAD(handle, sqlite3_config);
+        DYNLOAD(handle, sqlite3_db_config);
+        DYNLOAD(handle, sqlite3_extended_result_codes);
+        DYNLOAD(handle, sqlite3_last_insert_rowid);
+        DYNLOAD(handle, sqlite3_changes);
+        DYNLOAD(handle, sqlite3_total_changes);
+        DYNLOAD(handle, sqlite3_interrupt);
+        DYNLOAD(handle, sqlite3_complete);
+        DYNLOAD(handle, sqlite3_complete16);
+        DYNLOAD(handle, sqlite3_busy_handler);
+        DYNLOAD(handle, sqlite3_busy_timeout);
+        DYNLOAD(handle, sqlite3_get_table);
+        DYNLOAD(handle, sqlite3_free_table);
+        //   DYNLOAD(handle, sqlite3_realloc64);
+        DYNLOAD(handle, sqlite3_free);
+        //   DYNLOAD(handle, sqlite3_msize);
+        DYNLOAD(handle, sqlite3_memory_used);
+        DYNLOAD(handle, sqlite3_memory_highwater);
+        DYNLOAD(handle, sqlite3_randomness);
+        DYNLOAD(handle, sqlite3_set_authorizer);
+        DYNLOAD(handle, sqlite3_progress_handler);
+        DYNLOAD(handle, sqlite3_open);
+        DYNLOAD(handle, sqlite3_open16);
+        DYNLOAD(handle, sqlite3_open_v2);
+        //   DYNLOAD(handle, sqlite3_uri_boolean);
+        //   DYNLOAD(handle, sqlite3_uri_int64);
+        DYNLOAD(handle, sqlite3_errcode);
+        DYNLOAD(handle, sqlite3_errmsg);
+        DYNLOAD(handle, sqlite3_extended_errcode);
+        DYNLOAD(handle, sqlite3_limit);
+        DYNLOAD(handle, sqlite3_prepare);
+        DYNLOAD(handle, sqlite3_prepare_v2);
+        DYNLOAD(handle, sqlite3_prepare16);
+        DYNLOAD(handle, sqlite3_prepare16_v2);
+        //   DYNLOAD(handle, sqlite3_stmt_readonly);
+        //   DYNLOAD(handle, sqlite3_stmt_busy);
+        DYNLOAD(handle, sqlite3_bind_blob);
+        //   DYNLOAD(handle, sqlite3_bind_blob64);
+        DYNLOAD(handle, sqlite3_bind_double);
+        DYNLOAD(handle, sqlite3_bind_int);
+        DYNLOAD(handle, sqlite3_bind_int64);
+        DYNLOAD(handle, sqlite3_bind_null);
+        DYNLOAD(handle, sqlite3_bind_text);
+        DYNLOAD(handle, sqlite3_bind_text16);
+        //   DYNLOAD(handle, sqlite3_bind_text64);
+        DYNLOAD(handle, sqlite3_bind_value);
+        DYNLOAD(handle, sqlite3_bind_zeroblob);
+        DYNLOAD(handle, sqlite3_bind_parameter_count);
+        DYNLOAD(handle, sqlite3_bind_parameter_index);
+        DYNLOAD(handle, sqlite3_clear_bindings);
+        DYNLOAD(handle, sqlite3_column_count);
+        DYNLOAD(handle, sqlite3_step);
+        DYNLOAD(handle, sqlite3_data_count);
+        DYNLOAD(handle, sqlite3_column_bytes);
+        DYNLOAD(handle, sqlite3_column_bytes16);
+        DYNLOAD(handle, sqlite3_column_double);
+        DYNLOAD(handle, sqlite3_column_int);
+        DYNLOAD(handle, sqlite3_column_int64);
+        DYNLOAD(handle, sqlite3_column_text);
+        DYNLOAD(handle, sqlite3_column_type);
+        DYNLOAD(handle, sqlite3_column_value);
+        DYNLOAD(handle, sqlite3_finalize);
+        DYNLOAD(handle, sqlite3_reset);
+        DYNLOAD(handle, sqlite3_create_function);
+        DYNLOAD(handle, sqlite3_create_function16);
+        //   DYNLOAD(handle, sqlite3_create_function_v2);
+        DYNLOAD(handle, sqlite3_value_bytes);
+        DYNLOAD(handle, sqlite3_value_bytes16);
+        DYNLOAD(handle, sqlite3_value_double);
+        DYNLOAD(handle, sqlite3_value_int);
+        DYNLOAD(handle, sqlite3_value_int64);
+        DYNLOAD(handle, sqlite3_value_type);
+        DYNLOAD(handle, sqlite3_value_numeric_type);
+        DYNLOAD(handle, sqlite3_set_auxdata);
+        DYNLOAD(handle, sqlite3_result_blob);
+        //   DYNLOAD(handle, sqlite3_result_blob64);
+        DYNLOAD(handle, sqlite3_result_double);
+        DYNLOAD(handle, sqlite3_result_error);
+        DYNLOAD(handle, sqlite3_result_error16);
+        DYNLOAD(handle, sqlite3_result_error_toobig);
+        DYNLOAD(handle, sqlite3_result_error_nomem);
+        DYNLOAD(handle, sqlite3_result_error_code);
+        DYNLOAD(handle, sqlite3_result_int);
+        DYNLOAD(handle, sqlite3_result_int64);
+        DYNLOAD(handle, sqlite3_result_null);
+        DYNLOAD(handle, sqlite3_result_text);
+        //   DYNLOAD(handle, sqlite3_result_text64);
+        DYNLOAD(handle, sqlite3_result_text16);
+        DYNLOAD(handle, sqlite3_result_text16le);
+        DYNLOAD(handle, sqlite3_result_text16be);
+        DYNLOAD(handle, sqlite3_result_value);
+        DYNLOAD(handle, sqlite3_result_zeroblob);
+        DYNLOAD(handle, sqlite3_create_collation);
+        DYNLOAD(handle, sqlite3_create_collation_v2);
+        DYNLOAD(handle, sqlite3_create_collation16);
+        DYNLOAD(handle, sqlite3_collation_needed);
+        DYNLOAD(handle, sqlite3_collation_needed16);
+
+#ifdef SQLITE_HAS_CODEC
+        DYNLOAD(handle, sqlite3_key);
+        DYNLOAD(handle, sqlite3_key_v2);
+        DYNLOAD(handle, sqlite3_rekey);
+        DYNLOAD(handle, sqlite3_rekey_v2);
+        DYNLOAD(handle, sqlite3_activate_see);
+#endif
+#ifdef SQLITE_ENABLE_CEROD
+        DYNLOAD(handle, sqlite3_activate_cerod);
+#endif
+        DYNLOAD(handle, sqlite3_sleep);
+        DYNLOAD(handle, sqlite3_get_autocommit);
+        //   DYNLOAD(handle, sqlite3_db_readonly);
+        DYNLOAD(handle, sqlite3_next_stmt);
+        DYNLOAD(handle, sqlite3_enable_shared_cache);
+        DYNLOAD(handle, sqlite3_release_memory);
+        //   DYNLOAD(handle, sqlite3_db_release_memory);
+        //   DYNLOAD(handle, sqlite3_soft_heap_limit64);
+        DYNLOAD(handle, sqlite3_table_column_metadata);
+        DYNLOAD(handle, sqlite3_load_extension);
+        DYNLOAD(handle, sqlite3_enable_load_extension);
+        DYNLOAD(handle, sqlite3_auto_extension);
+        //   DYNLOAD(handle, sqlite3_cancel_auto_extension);
+        DYNLOAD(handle, sqlite3_reset_auto_extension);
+        DYNLOAD(handle, sqlite3_create_module);
+        DYNLOAD(handle, sqlite3_create_module_v2);
+        DYNLOAD(handle, sqlite3_declare_vtab);
+        DYNLOAD(handle, sqlite3_overload_function);
+        DYNLOAD(handle, sqlite3_blob_open);
+        DYNLOAD(handle, sqlite3_blob_close);
+        DYNLOAD(handle, sqlite3_blob_bytes);
+        DYNLOAD(handle, sqlite3_blob_read);
+        DYNLOAD(handle, sqlite3_blob_write);
+        DYNLOAD(handle, sqlite3_vfs_find);
+        DYNLOAD(handle, sqlite3_vfs_register);
+        DYNLOAD(handle, sqlite3_vfs_unregister);
+        DYNLOAD(handle, sqlite3_mutex_alloc);
+        DYNLOAD(handle, sqlite3_mutex_free);
+        DYNLOAD(handle, sqlite3_mutex_enter);
+        DYNLOAD(handle, sqlite3_mutex_try);
+        DYNLOAD(handle, sqlite3_mutex_leave);
+        // DYNLOAD(handle, sqlite3_mutex_held);
+        // DYNLOAD(handle, sqlite3_mutex_notheld);
+        DYNLOAD(handle, sqlite3_db_mutex);
+        DYNLOAD(handle, sqlite3_file_control);
+        DYNLOAD(handle, sqlite3_test_control);
+        DYNLOAD(handle, sqlite3_status);
+        DYNLOAD(handle, sqlite3_db_status);
+        DYNLOAD(handle, sqlite3_stmt_status);
+        DYNLOAD(handle, sqlite3_backup_init);
+        DYNLOAD(handle, sqlite3_backup_step);
+        DYNLOAD(handle, sqlite3_backup_finish);
+        DYNLOAD(handle, sqlite3_backup_remaining);
+        DYNLOAD(handle, sqlite3_backup_pagecount);
+        DYNLOAD(handle, sqlite3_unlock_notify);
+        //   DYNLOAD(handle, sqlite3_stricmp);
+        //   DYNLOAD(handle, sqlite3_strnicmp);
+        //   DYNLOAD(handle, sqlite3_strglob);
+        //   DYNLOAD(handle, sqlite3_log);
+        //   DYNLOAD(handle, sqlite3_wal_autocheckpoint);
+        //   DYNLOAD(handle, sqlite3_wal_checkpoint);
+        //   DYNLOAD(handle, sqlite3_wal_checkpoint_v2);
+        //   DYNLOAD(handle, sqlite3_vtab_config);
+        //   DYNLOAD(handle, sqlite3_vtab_on_conflict);
+        //   DYNLOAD(handle, sqlite3_rtree_geometry_callback);
+        //   DYNLOAD(handle, sqlite3_rtree_query_callback);
+
+        // check some functions for nullptr to verify if loading worked, otherwise throw
+        if (sqlite3_shutdown == nullptr || sqlite3_exec == nullptr)
+        {
+          throw sqlpp::exception("Initializing dynamically loaded SQLite3 functions failed");
+        }
+      }
+    }  // dynamic
+  }    // sqlite3
+}  // sqlpp
+
+#undef DYNDEFINE
+#undef DYNLOAD
+#endif

--- a/src/detail/prepared_statement_handle.h
+++ b/src/detail/prepared_statement_handle.h
@@ -29,10 +29,17 @@
 
 #include <sqlite3.h>
 
+#ifdef SQLPP_DYNAMIC_LOADING
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
+#endif
+
 namespace sqlpp
 {
   namespace sqlite3
   {
+#ifdef SQLPP_DYNAMIC_LOADING
+   using namespace dynamic;
+#endif
     namespace detail
     {
       struct prepared_statement_handle_t

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -36,6 +36,10 @@
 #if defined(__CYGWIN__)
 #include <sstream>
 
+#ifdef SQLPP_DYNAMIC_LOADING
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
+#endif
+
 // Workaround because cygwin gcc does not define to_string
 namespace std
 {
@@ -54,6 +58,9 @@ namespace sqlpp
 {
   namespace sqlite3
   {
+#ifdef SQLPP_DYNAMIC_LOADING
+   using namespace dynamic;
+#endif
     namespace
     {
       void check_bind_result(int result, const char* const type)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,3 +17,13 @@ build_and_run(WithTest)
 build_and_run(AttachTest)
 build_and_run(DynamicSelectTest)
 build_and_run(AutoIncrementTest)
+
+# the dynamic loading test needs the extra option "SQLPP_DYNAMIC_LOADING" and does NOT link the sqlite libs
+get_filename_component(SQLITE3_LIB_FILE ${SQLITE3_LIBRARIES} NAME)
+add_executable(Sqlpp11Sqlite3DynamicLoadingTest "DynamicLoadingTest.cpp" ${sqlpp_headers})
+target_link_libraries(Sqlpp11Sqlite3DynamicLoadingTest sqlpp11-connector-sqlite3-dynamic)
+if (NOT MSVC)
+    target_link_libraries(Sqlpp11Sqlite3DynamicLoadingTest dl)
+    target_compile_options(Sqlpp11Sqlite3DynamicLoadingTest INTERFACE -Wall -Wextra -pedantic)
+endif ()
+add_test(Sqlpp11Sqlite3DynamicLoadingTest Sqlpp11Sqlite3DynamicLoadingTest)

--- a/tests/DynamicLoadingTest.cpp
+++ b/tests/DynamicLoadingTest.cpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2013 - 2016, Roland Bock
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+ * OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TabSample.h"
+#include <sqlpp11/alias_provider.h>
+#include <sqlpp11/select.h>
+#include <sqlpp11/insert.h>
+#include <sqlpp11/update.h>
+#include <sqlpp11/remove.h>
+#include <sqlpp11/functions.h>
+#include <sqlpp11/transaction.h>
+#include <sqlpp11/multi_column.h>
+#include <sqlpp11/sqlite3/connection.h>
+
+#include <sqlite3.h>
+#include <iostream>
+#include <vector>
+
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
+
+SQLPP_ALIAS_PROVIDER(left);
+
+namespace sql = sqlpp::sqlite3;
+int main()
+{
+  sql::connection_config config;
+  config.path_to_database = ":memory:";
+  config.flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
+  config.debug = true;
+
+  sql::connection db(config);
+  db.execute("CREATE TABLE tab_sample (\
+        alpha bigint(20) DEFAULT NULL,\
+            beta varchar(255) DEFAULT NULL,\
+            gamma bool DEFAULT NULL\
+            )");
+
+  const auto tab = TabSample{};
+
+  auto i = insert_into(tab).columns(tab.beta, tab.gamma);
+  i.values.add(tab.beta = "rhabarbertorte", tab.gamma = false);
+  // i.values.add(tab.beta = "cheesecake", tab.gamma = false)
+  // i.values.add(tab.beta = "kaesekuchen", tab.gamma = true)
+  auto last_insert_rowid = db(i);
+
+  std::cerr << "last insert rowid: " << last_insert_rowid << std::endl;
+
+  // Just to demonstrate that you can call basically any function
+  std::cerr << "last insert rowid: "
+            << db(select(sqlpp::verbatim<sqlpp::integer>("last_insert_rowid()").as(tab.alpha))).front().alpha
+            << std::endl;
+
+  // select a static (alpha) and a dynamic column (beta)
+  auto s = dynamic_select(db).dynamic_columns(tab.alpha.as(left)).from(tab).unconditionally();
+  s.selected_columns.add(tab.beta);
+  s.selected_columns.add(tab.gamma);
+  for (const auto& row : db(s))
+  {
+    std::cerr << "row.alpha: " << row.left << ", row.beta: " << row.at("beta") << ", row.gamma: " << row.at("gamma")
+              << std::endl;
+  };
+  return 0;
+}

--- a/tests/SampleTest.cpp
+++ b/tests/SampleTest.cpp
@@ -35,6 +35,7 @@
 
 SQLPP_ALIAS_PROVIDER(left);
 SQLPP_ALIAS_PROVIDER(pragma);
+SQLPP_ALIAS_PROVIDER(sub);
 
 namespace sql = sqlpp::sqlite3;
 int main()
@@ -198,6 +199,17 @@ int main()
           .front()
           .pragma;
   std::cerr << pragmaValue << std::endl;
+
+  const auto subQuery = select(tab.alpha).from(tab).unconditionally().as(sub);
+  for (const auto& row : db(select(subQuery.alpha).from(subQuery).unconditionally()))
+  {
+    std::cerr << row.alpha;
+  }
+
+  for (const auto& row : db(select(subQuery.alpha).from(tab.inner_join(subQuery).unconditionally()).unconditionally()))
+  {
+    std::cerr << row.alpha;
+  }
 
   return 0;
 }

--- a/tests/SampleTest.cpp
+++ b/tests/SampleTest.cpp
@@ -200,6 +200,7 @@ int main()
           .pragma;
   std::cerr << pragmaValue << std::endl;
 
+  // Testing sub select tables and unconditional joins
   const auto subQuery = select(tab.alpha).from(tab).unconditionally().as(sub);
   for (const auto& row : db(select(subQuery.alpha).from(subQuery).unconditionally()))
   {


### PR DESCRIPTION
This changes implements dynamic loading of the SQLite library, so the applications built with SQLite support have no direct link dependency with the libsqlite3.so.

This can be switched on or off using the -DSQLPP11_DYNAMIC_LOADING=On (=Off) switch in CMake. I use it to build software that supports several databases without requiring all database libraries to be installed. I also have a patch for the PostgreSQL connector in the works.

The patch has two main caveats:
1. at the moment it uses dlopen and a hard-coded "libsqlite3.so", so it won't work on Windows and won't load the libsqlcipher instead of libsqlite in case that is activated
2. it prefers the dynamically loaded symbols instead of the global ones by pulling in their namespace in each source file using sqlite3_* functions with "using namespace dynamic;". Every sqlite call in a source file that is missing this directive will add a the library dependency again.

It would be great if you could have a look at the change and provide comments, or consider merging it.

Thanks and best regards, Volker