### PR TITLE
Added last_insert_id() function for Sqlite3

### DIFF
--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -311,6 +311,9 @@ namespace sqlpp
       //! report a rollback failure (will be called by transactions in case of a rollback failure in the destructor)
       void report_rollback_failure(const std::string message) noexcept;
 
+      //! get the last inserted id
+      uint64_t last_insert_id() noexcept;
+
       ::sqlite3* native_handle();
 
       auto attach(const connection_config&, const std::string name) -> schema_t;

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -224,6 +224,11 @@ namespace sqlpp
       std::cerr << "Sqlite3 message:" << message << std::endl;
     }
 
+    uint64_t connection::last_insert_id() noexcept
+    {
+      return sqlite3_last_insert_rowid(_handle->sqlite);
+    }
+
     auto connection::attach(const connection_config& config, const std::string name) -> schema_t
     {
       auto prepared =

--- a/tests/SampleTest.cpp
+++ b/tests/SampleTest.cpp
@@ -86,7 +86,9 @@ int main()
   // insert
   std::cerr << "no of required columns: " << TabSample::_required_insert_columns::size::value << std::endl;
   db(insert_into(tab).default_values());
+  std::cout << "Last Insert ID: " << db.last_insert_id() << "\n";
   db(insert_into(tab).set(tab.gamma = true));
+  std::cout << "Last Insert ID: " << db.last_insert_id() << "\n";
   auto di = dynamic_insert_into(db, tab).dynamic_set(tab.gamma = true);
   di.insert_list.add(tab.beta = "");
   db(di);


### PR DESCRIPTION
The PostgreSQL connector offers a last_insert_id() function which can query the last ID for auto increment fields of specific table. SQLite does not provide the ID per table, but using sqlite3_last_insert_rowid() you can retrieve the last "global" ID. This is often useful to directly refer to inserted data without "select"ing for it first.

The function is also available as an SQL command but I find a function on the connection much more convenient.

It would be great if you could have a short look at the function and comment on it or merge the change.

Thanks and best regards, Volker