### PR TITLE
Fixed SQLPP_DYNAMIC_LOADING define which slipped into another ifdef

### DIFF
--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -36,10 +36,6 @@
 #if defined(__CYGWIN__)
 #include <sstream>
 
-#ifdef SQLPP_DYNAMIC_LOADING
-#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
-#endif
-
 // Workaround because cygwin gcc does not define to_string
 namespace std
 {
@@ -52,6 +48,10 @@ namespace std
     return stream.str();
   }
 }
+#endif
+
+#ifdef SQLPP_DYNAMIC_LOADING
+#include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
 #endif
 
 namespace sqlpp


### PR DESCRIPTION
Hi! This is a small fix for the dynamic linking. One of the defines sits inside another #ifdef. This is not a problem for now as the file does not use any sqlite3_* functions directly, but should be fixed to avoid future pain.