### PR TITLE
fix: error: AddressSanitizer: stack-use-after-scope

### DIFF
--- a/tests/SelectTest.cpp
+++ b/tests/SelectTest.cpp
@@ -136,7 +136,7 @@ int main()
 
   std::cerr << "--------------------------------------" << std::endl;
   auto tx = start_transaction(db);
-  if (const auto& row = *db(select(all_of(tab), select(max(tab.alpha)).from(tab)).from(tab).unconditionally()).begin())
+  for (const auto& row : db(select(all_of(tab), select(max(tab.alpha)).from(tab)).from(tab).unconditionally()))
   {
     int x = row.alpha;
     int a = row.max;


### PR DESCRIPTION
Description:
AddressSanitizer reports stack usage after scope

How to reproduce:
Build sqlpp11-connector-sqlite3 with clang and -fsanitize=address
```
CC=clang CXX=clang++ cmake .. -DCMAKE_CXX_FLAGS="-g -fsanitize=address" -DHinnantDate_ROOT_DIR=~/work/github/3rdparty/date
make
make test

```
Error report:

> =================================================================
> ==26321==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fff9a9c0408 at pc 0x00000077379f bp 0x7fff9a9bdee0 sp 0x7fff9a9bded8
> READ of size 1 at 0x7fff9a9c0408 thread T0
>     #0 0x77379e in sqlpp::result_row_t<sqlpp::sqlite3::connection, sqlpp::field_spec_t<TabSample_::Alpha::_alias_t, sqlpp::integral, true, false>, sqlpp::field_spec_t<TabSample_::Beta::_alias_t, sqlpp::text, true, false>, sqlpp::field_spec_t<TabSample_::Gamma::_alias_t, sqlpp::boolean, false, false>, sqlpp::field_spec_t<sqlpp::max_alias_t::_alias_t, sqlpp::integral, true, false> >::operator bool() const sqlpp11-connector-sqlite3/../sqlpp11/include/sqlpp11/result_row.h:222:14
>     #1 0x768046 in main sqlpp11-connector-sqlite3/tests/SelectTest.cpp:139:19
>     #2 0x7f273e519c04 in __libc_start_main /usr/src/debug/glibc-2.17-c758a686/csu/../csu/libc-start.c:274
>     #3 0x652127 in _start (sqlpp11-connector-sqlite3/build/tests/Sqlpp11Sqlite3SelectTest+0x652127)
> 
> Address 0x7fff9a9c0408 is located in stack of thread T0 at offset 9448 in frame
>     #0 0x76314f in main sqlpp11-connector-sqlite3/tests/SelectTest.cpp:74
> 
>   This frame has 179 object(s):
>     [32, 48) 'db' (line 75)
> ...

