### PR TITLE
prepared_statement: include <cmath> for isnan/isinf

### DIFF
--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -32,6 +32,7 @@
 #include <sqlpp11/sqlite3/prepared_statement.h>
 #include <sstream>
 #include <string>
+#include <cmath>
 
 #if defined(__CYGWIN__)
 #include <sstream>


### PR DESCRIPTION
I was running into an issue when building this repo with GCC 7.1.1 and bazel caused by the missing include for `std::isnan` and `std::isinf`.