### PR TITLE
connection: only print sqlite3_step return code if debug is enabled

### DIFF
--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -76,7 +76,8 @@ namespace sqlpp
           case SQLITE_DONE:
             return;
           default:
-            std::cerr << "Sqlite3 debug: sqlite3_step return code: " << rc << std::endl;
+            if(handle.config.debug)
+              std::cerr << "Sqlite3 debug: sqlite3_step return code: " << rc << std::endl;
             throw sqlpp::exception("Sqlite3 error: Could not execute statement: " +
                                    std::string(sqlite3_errmsg(handle.sqlite)));
         }


### PR DESCRIPTION
Print was missing debug check.
All other occurences of output to std::cerr are debug-guarded except for failure to close database in `src/detail/connection_handle.cpp` (where verbosity makes sense as destructor has no way to report the issue)