### PR TITLE
Fix return type of run_prepared_execute

### DIFF
--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -264,8 +264,8 @@ namespace sqlpp
         return prepare_impl(context.str());
       }
 
-      template <typename PreparedInsert>
-      void run_prepared_execute(const PreparedInsert& x)
+      template <typename PreparedExecute>
+      size_t run_prepared_execute(const PreparedExecute& x)
       {
         x._prepared_statement._reset();
         x._bind_params();


### PR DESCRIPTION
While creating a prepared execute (generic statement that is not an select, insert, update or delete), my compiler correctly complained. Fixed it quickly :)