### PR TITLE
added move support to the connection (#60)

### DIFF
--- a/include/sqlpp11/sqlite3/connection.h
+++ b/include/sqlpp11/sqlite3/connection.h
@@ -137,11 +137,11 @@ namespace sqlpp
       }
 
       connection(connection_config config);
+      connection(connection&&) noexcept;
+      connection& operator=(connection&&) noexcept;
       ~connection();
       connection(const connection&) = delete;
-      connection(connection&&) = delete;
       connection& operator=(const connection&) = delete;
-      connection& operator=(connection&&) = delete;
 
       //! select returns a result (which can be iterated row by row)
       template <typename Select>

--- a/src/connection.cpp
+++ b/src/connection.cpp
@@ -89,6 +89,9 @@ namespace sqlpp
     {
     }
 
+    connection::connection(connection&&) noexcept = default;
+    connection& connection::operator=(connection&&) noexcept = default;
+
     connection::~connection()
     {
     }


### PR DESCRIPTION
This commit adds move constructor and move assignment operator to the connection class (as discussed in #60).
The implementation can be defaulted, since the "real" handle is stored in a unique_ptr.