### PR TITLE
Feature/uint support

### DIFF
--- a/include/sqlpp11/sqlite3/bind_result.h
+++ b/include/sqlpp11/sqlite3/bind_result.h
@@ -33,7 +33,7 @@
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4251)
+#pragma warning(disable : 4251)
 #endif
 
 namespace sqlpp
@@ -90,6 +90,7 @@ namespace sqlpp
       void _bind_boolean_result(size_t index, signed char* value, bool* is_null);
       void _bind_floating_point_result(size_t index, double* value, bool* is_null);
       void _bind_integral_result(size_t index, int64_t* value, bool* is_null);
+      void _bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null);
       void _bind_text_result(size_t index, const char** text, size_t* len);
       void _bind_blob_result(size_t index, const uint8_t** text, size_t* len);
       void _bind_date_result(size_t index, ::sqlpp::chrono::day_point* value, bool* is_null);
@@ -98,8 +99,8 @@ namespace sqlpp
     private:
       bool next_impl();
     };
-  }
-}
+  }  // namespace sqlite3
+}  // namespace sqlpp
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/include/sqlpp11/sqlite3/prepared_statement.h
+++ b/include/sqlpp11/sqlite3/prepared_statement.h
@@ -28,14 +28,14 @@
 #define SQLPP_SQLITE3_PREPARED_STATEMENT_H
 
 #include <memory>
-#include <string>
-#include <vector>
 #include <sqlpp11/chrono.h>
 #include <sqlpp11/sqlite3/export.h>
+#include <string>
+#include <vector>
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4251)
+#pragma warning(disable : 4251)
 #endif
 
 namespace sqlpp
@@ -72,13 +72,14 @@ namespace sqlpp
       void _bind_boolean_parameter(size_t index, const signed char* value, bool is_null);
       void _bind_floating_point_parameter(size_t index, const double* value, bool is_null);
       void _bind_integral_parameter(size_t index, const int64_t* value, bool is_null);
+      void _bind_unsigned_integral_parameter(size_t index, const uint64_t* value, bool is_null);
       void _bind_text_parameter(size_t index, const std::string* value, bool is_null);
       void _bind_date_parameter(size_t index, const ::sqlpp::chrono::day_point* value, bool is_null);
       void _bind_date_time_parameter(size_t index, const ::sqlpp::chrono::microsecond_point* value, bool is_null);
       void _bind_blob_parameter(size_t index, const std::vector<uint8_t>* value, bool is_null);
     };
-  }
-}
+  }  // namespace sqlite3
+}  // namespace sqlpp
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -92,7 +92,7 @@ namespace sqlpp
         std::cerr << "Sqlite3 debug: binding unsigned integral result " << *value << " at index: " << index
                   << std::endl;
 
-      *value = sqlite3_column_int64(_handle->sqlite_statement, static_cast<int>(index));
+      *value = static_cast<uint64_t>(sqlite3_column_int64(_handle->sqlite_statement, static_cast<int>(index)));
       *is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
     }
 

--- a/src/bind_result.cpp
+++ b/src/bind_result.cpp
@@ -24,14 +24,14 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ciso646>
+#include "detail/prepared_statement_handle.h"
 #include <cctype>
-#include <iostream>
-#include <vector>
+#include <ciso646>
 #include <date/date.h>  // Howard Hinnant's date library
+#include <iostream>
 #include <sqlpp11/exception.h>
 #include <sqlpp11/sqlite3/bind_result.h>
-#include "detail/prepared_statement_handle.h"
+#include <vector>
 
 #ifdef SQLPP_DYNAMIC_LOADING
 #include <sqlpp11/sqlite3/dynamic_libsqlite3.h>
@@ -86,6 +86,16 @@ namespace sqlpp
       *is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
     }
 
+    void bind_result_t::_bind_unsigned_integral_result(size_t index, uint64_t* value, bool* is_null)
+    {
+      if (_handle->debug)
+        std::cerr << "Sqlite3 debug: binding unsigned integral result " << *value << " at index: " << index
+                  << std::endl;
+
+      *value = sqlite3_column_int64(_handle->sqlite_statement, static_cast<int>(index));
+      *is_null = sqlite3_column_type(_handle->sqlite_statement, static_cast<int>(index)) == SQLITE_NULL;
+    }
+
     void bind_result_t::_bind_text_result(size_t index, const char** value, size_t* len)
     {
       if (_handle->debug)
@@ -100,7 +110,8 @@ namespace sqlpp
       if (_handle->debug)
         std::cerr << "Sqlite3 debug: binding text result at index: " << index << std::endl;
 
-      *value = (reinterpret_cast<const uint8_t*>(sqlite3_column_blob(_handle->sqlite_statement, static_cast<int>(index))));
+      *value =
+          (reinterpret_cast<const uint8_t*>(sqlite3_column_blob(_handle->sqlite_statement, static_cast<int>(index))));
       *len = sqlite3_column_bytes(_handle->sqlite_statement, static_cast<int>(index));
     }
 
@@ -132,7 +143,7 @@ namespace sqlpp
         }
         return true;
       }
-    }
+    }  // namespace
 
     void bind_result_t::_bind_date_result(size_t index, ::sqlpp::chrono::day_point* value, bool* is_null)
     {
@@ -234,5 +245,5 @@ namespace sqlpp
           throw sqlpp::exception("Sqlite3 error: Unexpected return value for sqlite3_step()");
       }
     }
-  }
-}
+  }  // namespace sqlite3
+}  // namespace sqlpp

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -160,7 +160,8 @@ namespace sqlpp
 
       int result;
       if (not is_null)
-        result = sqlite3_bind_int64(_handle->sqlite_statement, static_cast<int>(index + 1), *value);
+        result =
+            sqlite3_bind_int64(_handle->sqlite_statement, static_cast<int>(index + 1), static_cast<int64_t>(*value));
       else
         result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
       check_bind_result(result, "integral");

--- a/src/prepared_statement.cpp
+++ b/src/prepared_statement.cpp
@@ -26,13 +26,13 @@
 
 #include "detail/prepared_statement_handle.h"
 #include <ciso646>
+#include <cmath>
 #include <date/date.h>
 #include <iostream>
 #include <sqlpp11/exception.h>
 #include <sqlpp11/sqlite3/prepared_statement.h>
 #include <sstream>
 #include <string>
-#include <cmath>
 
 #if defined(__CYGWIN__)
 #include <sstream>
@@ -48,7 +48,7 @@ namespace std
     stream << t;
     return stream.str();
   }
-}
+}  // namespace std
 #endif
 
 #ifdef SQLPP_DYNAMIC_LOADING
@@ -60,7 +60,7 @@ namespace sqlpp
   namespace sqlite3
   {
 #ifdef SQLPP_DYNAMIC_LOADING
-   using namespace dynamic;
+    using namespace dynamic;
 #endif
     namespace
     {
@@ -77,11 +77,11 @@ namespace sqlpp
           case SQLITE_TOOBIG:
             throw sqlpp::exception("Sqlite3 error: " + std::string(type) + " bind too big");
           default:
-            throw sqlpp::exception("Sqlite3 error: " + std::string(type) + " bind returned unexpected value: " +
-                                   std::to_string(result));
+            throw sqlpp::exception("Sqlite3 error: " + std::string(type) +
+                                   " bind returned unexpected value: " + std::to_string(result));
         }
       }
-    }
+    }  // namespace
 
     prepared_statement_t::prepared_statement_t(std::shared_ptr<detail::prepared_statement_handle_t>&& handle)
         : _handle(std::move(handle))
@@ -127,7 +127,8 @@ namespace sqlpp
           if (*value > std::numeric_limits<double>::max())
             result = sqlite3_bind_text(_handle->sqlite_statement, static_cast<int>(index + 1), "Inf", 3, SQLITE_STATIC);
           else
-            result = sqlite3_bind_text(_handle->sqlite_statement, static_cast<int>(index + 1), "-Inf", 4, SQLITE_STATIC);
+            result =
+                sqlite3_bind_text(_handle->sqlite_statement, static_cast<int>(index + 1), "-Inf", 4, SQLITE_STATIC);
         }
         else
           result = sqlite3_bind_double(_handle->sqlite_statement, static_cast<int>(index + 1), *value);
@@ -142,6 +143,20 @@ namespace sqlpp
       if (_handle->debug)
         std::cerr << "Sqlite3 debug: binding integral parameter " << *value << " at index: " << index << ", being "
                   << (is_null ? "" : "not ") << "null" << std::endl;
+
+      int result;
+      if (not is_null)
+        result = sqlite3_bind_int64(_handle->sqlite_statement, static_cast<int>(index + 1), *value);
+      else
+        result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
+      check_bind_result(result, "integral");
+    }
+
+    void prepared_statement_t::_bind_unsigned_integral_parameter(size_t index, const uint64_t* value, bool is_null)
+    {
+      if (_handle->debug)
+        std::cerr << "Sqlite3 debug: binding unsigned integral parameter " << *value << " at index: " << index
+                  << ", being " << (is_null ? "" : "not ") << "null" << std::endl;
 
       int result;
       if (not is_null)
@@ -220,10 +235,10 @@ namespace sqlpp
       int result;
       if (not is_null)
         result = sqlite3_bind_blob(_handle->sqlite_statement, static_cast<int>(index + 1), value->data(),
-                                     static_cast<int>(value->size()), SQLITE_STATIC);
+                                   static_cast<int>(value->size()), SQLITE_STATIC);
       else
         result = sqlite3_bind_null(_handle->sqlite_statement, static_cast<int>(index + 1));
       check_bind_result(result, "blob");
     }
-  }
-}
+  }  // namespace sqlite3
+}  // namespace sqlpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 macro (build_and_run arg)
 	# Add headers to sources to enable file browsing in IDEs
-	add_executable(Sqlpp11Sqlite3${arg} ${arg}.cpp)
+    add_executable(Sqlpp11Sqlite3${arg} ${arg}.cpp)
 
 	target_link_libraries(Sqlpp11Sqlite3${arg} PRIVATE sqlpp11-connector-sqlite3)
 	if (NOT MSVC)

--- a/tests/FloatingPointTest.cpp
+++ b/tests/FloatingPointTest.cpp
@@ -34,7 +34,6 @@
 #endif
 #include <iostream>
 #include <limits>
-#include <sqlite3.h>
 
 namespace sql = sqlpp::sqlite3;
 

--- a/tests/IntegralSample.h
+++ b/tests/IntegralSample.h
@@ -1,0 +1,79 @@
+#ifndef INTEGRAL_SAMPLE_H
+#define INTEGRAL_SAMPLE_H
+
+#include <sqlpp11/char_sequence.h>
+#include <sqlpp11/data_types.h>
+#include <sqlpp11/table.h>
+
+namespace IntegralSample_
+{
+  struct SignedValue
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] = "signed_value";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template <typename T>
+      struct _member_t
+      {
+        T signedValue;
+        T& operator()()
+        {
+          return signedValue;
+        }
+        const T& operator()() const
+        {
+          return signedValue;
+        }
+      };
+    };
+    using _traits = sqlpp::make_traits<sqlpp::integer, sqlpp::tag::can_be_null>;
+  };
+  struct UnsignedValue
+  {
+    struct _alias_t
+    {
+      static constexpr const char _literal[] = "unsigned_value";
+      using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+      template <typename T>
+      struct _member_t
+      {
+        T unsignedValue;
+        T& operator()()
+        {
+          return unsignedValue;
+        }
+        const T& operator()() const
+        {
+          return unsignedValue;
+        }
+      };
+    };
+    using _traits = sqlpp::make_traits<sqlpp::integer_unsigned, sqlpp::tag::can_be_null>;
+  };
+
+}  // namespace IntegralSample_
+
+struct IntegralSample : sqlpp::table_t<IntegralSample, IntegralSample_::SignedValue, IntegralSample_::UnsignedValue>
+{
+  struct _alias_t
+  {
+    static constexpr const char _literal[] = "integral_sample";
+    using _name_t = sqlpp::make_char_sequence<sizeof(_literal), _literal>;
+    template <typename T>
+    struct _member_t
+    {
+      T fpSample;
+      T& operator()()
+      {
+        return fpSample;
+      }
+      const T& operator()() const
+      {
+        return fpSample;
+      }
+    };
+  };
+};
+
+#endif

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -65,15 +65,18 @@ int main()
       unsigned_value INTEGER
   ))");
 
-  // Supported range for unsigned value (as int64 is the maximum)
+  // The connector supports uint64_t values and will always retrieve the correct value from the database.
+  // Sqlite3 stores the values as int64_t internally though, so big uint64_t values will be converted
+  // and the library has to intepret the int64_t values correctly as uint64_t.
+  // Therefore, we test uint64_t values in an out of the range of int64_t and test if they are retrieved
+  // correctly from the database in both cases.
   uint64_t unsignedVal = std::numeric_limits<int64_t>::max();
   auto signedVal = std::numeric_limits<int64_t>::max();
 
-  db(insert_into(intSample).set(intSample.signedValue = unsignedVal, intSample.unsignedValue = signedVal));
-
-  // Unsupported range for unsigned value (as int64 is the maximum)
-  std::size_t unsignedValUnsupported = std::numeric_limits<uint64_t>::max();
+  uint64_t unsignedValUnsupported = std::numeric_limits<uint64_t>::max();
   auto signedValNeg = std::numeric_limits<int64_t>::min();
+
+  db(insert_into(intSample).set(intSample.signedValue = unsignedVal, intSample.unsignedValue = signedVal));
 
   auto prepared_insert =
       db.prepare(insert_into(intSample).set(intSample.signedValue = parameter(intSample.signedValue),

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -76,6 +76,8 @@ int main()
   uint64_t unsignedValUnsupported = std::numeric_limits<uint64_t>::max();
   auto signedValNeg = std::numeric_limits<int64_t>::min();
 
+  std::size_t size_t_value = std::numeric_limits<std::size_t>::max();
+
   db(insert_into(intSample).set(intSample.signedValue = unsignedVal, intSample.unsignedValue = signedVal));
 
   auto prepared_insert =
@@ -85,16 +87,22 @@ int main()
   prepared_insert.params.unsignedValue = unsignedValUnsupported;
   db(prepared_insert);
 
+  db(insert_into(intSample).set(intSample.signedValue = size_t_value, intSample.unsignedValue = size_t_value));
+
   auto q = select(intSample.signedValue, intSample.unsignedValue).from(intSample).unconditionally();
 
   auto rows = db(q);
 
-  require_equal(__LINE__, rows.front().signedValue.value(), signedVal);
-  require_equal(__LINE__, rows.front().unsignedValue.value(), unsignedVal);
+  require_equal(__LINE__, rows.front().signedValue, signedVal);
+  require_equal(__LINE__, rows.front().unsignedValue, unsignedVal);
   rows.pop_front();
 
-  require_equal(__LINE__, rows.front().signedValue.value(), signedValNeg);
-  require_equal(__LINE__, rows.front().unsignedValue.value(), unsignedValUnsupported);
+  require_equal(__LINE__, rows.front().signedValue, signedValNeg);
+  require_equal(__LINE__, rows.front().unsignedValue, unsignedValUnsupported);
+  rows.pop_front();
+
+  require_equal(__LINE__, rows.front().signedValue, size_t_value);
+  require_equal(__LINE__, rows.front().unsignedValue, size_t_value);
   rows.pop_front();
 
   return 0;

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -86,12 +86,12 @@ int main()
 
   auto rows = db(q);
 
-  require_equal(__LINE__, rows.front().signedValue, signedVal);
-  require_equal(__LINE__, rows.front().unsignedValue, unsignedVal);
+  require_equal(__LINE__, rows.front().signedValue.value(), signedVal);
+  require_equal(__LINE__, rows.front().unsignedValue.value(), unsignedVal);
   rows.pop_front();
 
-  require_equal(__LINE__, rows.front().signedValue, signedValNeg);
-  require_equal(__LINE__, rows.front().unsignedValue, unsignedValUnsupported);
+  require_equal(__LINE__, rows.front().signedValue.value(), signedValNeg);
+  require_equal(__LINE__, rows.front().unsignedValue.value(), unsignedValUnsupported);
   rows.pop_front();
 
   return 0;

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -55,7 +55,7 @@ auto require_equal(int line, const L& l, const R& r) -> void
 int main()
 {
   sql::connection_config config;
-  config.path_to_database = ":memory:";
+  config.path_to_database = "test.sqlite3";
   config.flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
   config.debug = true;
 
@@ -65,25 +65,38 @@ int main()
       unsigned_value INTEGER
   ))");
 
-  uint64_t unsignedVal = 17032080461028570721ULL;
-  auto signedVal = static_cast<int64_t>(unsignedVal);
+  // Supported range for unsigned value (as int64 is the maximum)
+  uint64_t unsignedVal = std::numeric_limits<int64_t>::max();
+  auto signedVal = std::numeric_limits<int64_t>::max();
+  std::cout << "Unsigned Value Supported Before: " << unsignedVal << "\n";
 
   db(insert_into(intSample).set(intSample.signedValue = unsignedVal, intSample.unsignedValue = signedVal));
+
+  // Supported range for unsigned value (as int64 is the maximum)
+  uint64_t unsignedValUnsupported = std::numeric_limits<uint64_t>::max();
+  auto signedValNeg = std::numeric_limits<int64_t>::min();
+  std::cout << "Unsigned Value Unsupported Before: " << unsignedValUnsupported << "\n";
 
   auto prepared_insert =
       db.prepare(insert_into(intSample).set(intSample.signedValue = parameter(intSample.signedValue),
                                             intSample.unsignedValue = parameter(intSample.unsignedValue)));
-  prepared_insert.params.signedValue = signedVal;
-  prepared_insert.params.unsignedValue = unsignedVal;
+  prepared_insert.params.signedValue = signedValNeg;
+  prepared_insert.params.unsignedValue = unsignedValUnsupported;
   db(prepared_insert);
 
   auto q = select(intSample.signedValue, intSample.unsignedValue).from(intSample).unconditionally();
 
-  for (const auto& row : db(q))
-  {
-    require_equal(__LINE__, row.signedValue.value(), signedVal);
-    require_equal(__LINE__, row.unsignedValue.value(), unsignedVal);
-  }
+  auto rows = db(q);
+
+  require_equal(__LINE__, rows.front().signedValue, signedVal);
+  require_equal(__LINE__, rows.front().unsignedValue, unsignedVal);
+  std::cout << "Unsigned Value Supported After: " << rows.front().unsignedValue << "\n";
+  rows.pop_front();
+
+  require_equal(__LINE__, rows.front().signedValue, signedValNeg);
+  require_equal(__LINE__, rows.front().unsignedValue, unsignedValUnsupported);
+  std::cout << "Unsigned Value Unsupported After: " << rows.front().unsignedValue << "\n";
+  rows.pop_front();
 
   return 0;
 }

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -82,7 +82,7 @@ int main()
   uint32_t uint32_t_value = std::numeric_limits<uint32_t>::max();
   int32_t int32_t_value = std::numeric_limits<int32_t>::max();
 
-  db(insert_into(intSample).set(intSample.signedValue = int64_t_value_min,
+  db(insert_into(intSample).set(intSample.signedValue = int64_t_value_max,
                                 intSample.unsignedValue = uint64_t_value_supported));
 
   auto prepared_insert =
@@ -99,20 +99,20 @@ int main()
 
   auto rows = db(q);
 
-  require_equal(__LINE__, rows.front().signedValue, int64_t_value_min);
-  require_equal(__LINE__, rows.front().unsignedValue, uint64_t_value_supported);
+  require_equal(__LINE__, rows.front().signedValue.value(), int64_t_value_max);
+  require_equal(__LINE__, rows.front().unsignedValue.value(), uint64_t_value_supported);
   rows.pop_front();
 
-  require_equal(__LINE__, rows.front().signedValue, int64_t_value_min);
-  require_equal(__LINE__, rows.front().unsignedValue, uint64_t_value_unsupported);
+  require_equal(__LINE__, rows.front().signedValue.value(), int64_t_value_min);
+  require_equal(__LINE__, rows.front().unsignedValue.value(), uint64_t_value_unsupported);
   rows.pop_front();
 
-  require_equal(__LINE__, rows.front().signedValue, size_t_value_min);
-  require_equal(__LINE__, rows.front().unsignedValue, size_t_value_max);
+  require_equal(__LINE__, rows.front().signedValue.value(), size_t_value_min);
+  require_equal(__LINE__, rows.front().unsignedValue.value(), size_t_value_max);
   rows.pop_front();
 
-  require_equal(__LINE__, rows.front().signedValue, int32_t_value);
-  require_equal(__LINE__, rows.front().unsignedValue, uint32_t_value);
+  require_equal(__LINE__, rows.front().signedValue.value(), int32_t_value);
+  require_equal(__LINE__, rows.front().unsignedValue.value(), uint32_t_value);
   rows.pop_front();
 
   return 0;

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -55,7 +55,7 @@ auto require_equal(int line, const L& l, const R& r) -> void
 int main()
 {
   sql::connection_config config;
-  config.path_to_database = "test.sqlite3";
+  config.path_to_database = ":memory:";
   config.flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
   config.debug = true;
 
@@ -68,14 +68,12 @@ int main()
   // Supported range for unsigned value (as int64 is the maximum)
   uint64_t unsignedVal = std::numeric_limits<int64_t>::max();
   auto signedVal = std::numeric_limits<int64_t>::max();
-  std::cout << "Unsigned Value Supported Before: " << unsignedVal << "\n";
 
   db(insert_into(intSample).set(intSample.signedValue = unsignedVal, intSample.unsignedValue = signedVal));
 
-  // Supported range for unsigned value (as int64 is the maximum)
-  uint64_t unsignedValUnsupported = std::numeric_limits<uint64_t>::max();
+  // Unsupported range for unsigned value (as int64 is the maximum)
+  std::size_t unsignedValUnsupported = std::numeric_limits<uint64_t>::max();
   auto signedValNeg = std::numeric_limits<int64_t>::min();
-  std::cout << "Unsigned Value Unsupported Before: " << unsignedValUnsupported << "\n";
 
   auto prepared_insert =
       db.prepare(insert_into(intSample).set(intSample.signedValue = parameter(intSample.signedValue),
@@ -90,12 +88,10 @@ int main()
 
   require_equal(__LINE__, rows.front().signedValue, signedVal);
   require_equal(__LINE__, rows.front().unsignedValue, unsignedVal);
-  std::cout << "Unsigned Value Supported After: " << rows.front().unsignedValue << "\n";
   rows.pop_front();
 
   require_equal(__LINE__, rows.front().signedValue, signedValNeg);
   require_equal(__LINE__, rows.front().unsignedValue, unsignedValUnsupported);
-  std::cout << "Unsigned Value Unsupported After: " << rows.front().unsignedValue << "\n";
   rows.pop_front();
 
   return 0;

--- a/tests/IntegralTest.cpp
+++ b/tests/IntegralTest.cpp
@@ -34,7 +34,6 @@
 #endif
 #include <iostream>
 #include <limits>
-#include <sqlite3.h>
 
 namespace sql = sqlpp::sqlite3;
 


### PR DESCRIPTION
Hi Roland, 

I saw in my project that the lib currently fails for integer_unsigned values and I also saw that someone has made in the past attempts to implement it (#25), so I picked it up. Hopefully we can get this in this time :) 

It seems to work with my test I wrote. I see an issue though with it yet. The sqlite3 lib doesn't natively support uint values, all integers are signed (https://www.sqlite.org/datatype3.html), therefore there is actually no real unsigned support (it's rather so there, so using the lib will be easier ... no casts needed). I'm not quite sure though what happens if you actually throw in a value, which is out of range (i.e fits into unsigned, but doesn't fit into signed). 
Any thoughts on this?

And I kinda screwed up with git as I have changed from master and from the development branch (my last fetch Content stuff directly went into master rather than development). So I based it now on master as well (but got commits from development). 